### PR TITLE
Remove dependencies on libc and rustc-serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ dev = ["clippy"]
 arrayvec = "0.4"
 clippy = {version = "0.0", optional = true}
 rand = "0.4"
-libc = "0.2"
 
 [dev-dependencies]
 hex = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,6 @@ arrayvec = "0.4"
 clippy = {version = "0.0", optional = true}
 rand = "0.4"
 libc = "0.2"
-rustc-serialize = "0.3"
+
+[dev-dependencies]
+hex = "0.3.1"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -18,8 +18,7 @@
 //! not be needed for most users.
 use std::mem;
 use std::hash;
-
-use libc::{c_int, c_uchar, c_uint, c_void, size_t};
+use std::os::raw::{c_int, c_uchar, c_uint, c_void};
 
 /// Flag for context to enable no precomputation
 pub const SECP256K1_START_NONE: c_uint = (1 << 0) | 0;
@@ -137,25 +136,25 @@ extern "C" {
 
     // Pubkeys
     pub fn secp256k1_ec_pubkey_parse(cx: *const Context, pk: *mut PublicKey,
-                                     input: *const c_uchar, in_len: size_t)
+                                     input: *const c_uchar, in_len: usize)
                                      -> c_int;
 
     pub fn secp256k1_ec_pubkey_serialize(cx: *const Context, output: *const c_uchar,
-                                         out_len: *mut size_t, pk: *const PublicKey
-,                                        compressed: c_uint)
+                                         out_len: *mut usize, pk: *const PublicKey,
+                                         compressed: c_uint)
                                          -> c_int;
 
     // Signatures
     pub fn secp256k1_ecdsa_signature_parse_der(cx: *const Context, sig: *mut Signature,
-                                               input: *const c_uchar, in_len: size_t)
+                                               input: *const c_uchar, in_len: usize)
                                                -> c_int;
 
     pub fn ecdsa_signature_parse_der_lax(cx: *const Context, sig: *mut Signature,
-                                         input: *const c_uchar, in_len: size_t)
+                                         input: *const c_uchar, in_len: usize)
                                          -> c_int;
 
     pub fn secp256k1_ecdsa_signature_serialize_der(cx: *const Context, output: *const c_uchar,
-                                                   out_len: *mut size_t, sig: *const Signature)
+                                                   out_len: *mut usize, sig: *const Signature)
                                                    -> c_int;
 
     pub fn secp256k1_ecdsa_recoverable_signature_parse_compact(cx: *const Context, sig: *mut RecoverableSignature,

--- a/src/key.rs
+++ b/src/key.rs
@@ -189,7 +189,7 @@ impl PublicKey {
         let mut pk = unsafe { ffi::PublicKey::blank() };
         unsafe {
             if ffi::secp256k1_ec_pubkey_parse(secp.ctx, &mut pk, data.as_ptr(),
-                                              data.len() as ::libc::size_t) == 1 {
+                                              data.len() as usize) == 1 {
                 Ok(PublicKey(pk))
             } else {
                 Err(InvalidPublicKey)
@@ -205,7 +205,7 @@ impl PublicKey {
         let mut ret = ArrayVec::new();
 
         unsafe {
-            let mut ret_len = constants::PUBLIC_KEY_SIZE as ::libc::size_t;
+            let mut ret_len = constants::PUBLIC_KEY_SIZE as usize;
             let compressed = if compressed { ffi::SECP256K1_SER_COMPRESSED } else { ffi::SECP256K1_SER_UNCOMPRESSED };
             let err = ffi::secp256k1_ec_pubkey_serialize(secp.ctx, ret.as_ptr(),
                                                          &mut ret_len, self.as_ptr(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,6 @@
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 
 extern crate arrayvec;
-extern crate rustc_serialize as serialize;
-
 extern crate libc;
 extern crate rand;
 
@@ -539,8 +537,8 @@ impl Secp256k1 {
 
 #[cfg(test)]
 mod tests {
+    extern crate hex;
     use rand::{Rng, thread_rng};
-    use serialize::hex::FromHex;
 
     use key::{SecretKey, PublicKey};
     use super::constants;
@@ -548,7 +546,7 @@ mod tests {
     use super::Error::{InvalidMessage, InvalidPublicKey, IncorrectSignature, InvalidSignature,
                        IncapableContext};
 
-    macro_rules! hex (($hex:expr) => ($hex.from_hex().unwrap()));
+    macro_rules! hex (($hex:expr) => (hex::decode($hex).unwrap()));
 
     #[test]
     fn capabilities() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,10 +40,8 @@
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 
 extern crate arrayvec;
-extern crate libc;
 extern crate rand;
 
-use libc::size_t;
 use std::{error, fmt, ops, ptr};
 use rand::Rng;
 
@@ -92,7 +90,7 @@ impl Signature {
 
         unsafe {
             if ffi::secp256k1_ecdsa_signature_parse_der(secp.ctx, &mut ret,
-                                                        data.as_ptr(), data.len() as libc::size_t) == 1 {
+                                                        data.as_ptr(), data.len() as usize) == 1 {
                 Ok(Signature(ret))
             } else {
                 Err(Error::InvalidSignature)
@@ -108,7 +106,7 @@ impl Signature {
         unsafe {
             let mut ret = ffi::Signature::blank();
             if ffi::ecdsa_signature_parse_der_lax(secp.ctx, &mut ret,
-                                                  data.as_ptr(), data.len() as libc::size_t) == 1 {
+                                                  data.as_ptr(), data.len() as usize) == 1 {
                 Ok(Signature(ret))
             } else {
                 Err(Error::InvalidSignature)
@@ -158,7 +156,7 @@ impl Signature {
     /// Serializes the signature in DER format
     pub fn serialize_der(&self, secp: &Secp256k1) -> Vec<u8> {
         let mut ret = Vec::with_capacity(72);
-        let mut len: size_t = ret.capacity() as size_t;
+        let mut len: usize = ret.capacity() as usize;
         unsafe {
             let err = ffi::secp256k1_ecdsa_signature_serialize_der(secp.ctx, ret.as_mut_ptr(),
                                                                    &mut len, self.as_ptr());


### PR DESCRIPTION
Removing `rustc-serialize` is the most important change. Removing `libc` is just as a general cleanup.

After this PR, this crate successfully compiles to wasm.