### PR TITLE
[Cargo.toml] update rand to 0.6 (breaking change)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "eth-secp256k1"
 version = "0.5.7"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
@@ -11,8 +10,8 @@ documentation = "https://www.wpsoftware.net/rustdoc/secp256k1/"
 description = "Fork of Rust bindings for Pieter Wuille's `libsecp256k1` library. Implements ECDSA for the SECG elliptic curve group secp256k1 and related utilities."
 keywords = [ "crypto", "ECDSA", "secp256k1", "libsecp256k1", "bitcoin" ]
 readme = "README.md"
-
 build = "build.rs"
+
 [build-dependencies]
 cc = "1.0"
 cfg-if = "0.1"
@@ -29,7 +28,7 @@ dev = ["clippy"]
 [dependencies]
 arrayvec = "0.4"
 clippy = {version = "0.0", optional = true}
-rand = "0.4"
+rand = "0.6"
 
 [dev-dependencies]
 hex = "0.3.1"


### PR DESCRIPTION
Used in https://github.com/paritytech/parity-ethereum/pull/10670/files#diff-c47a4637dec66e56691f4a199e184a25R11