### PR TITLE
Publish crate to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "eth-secp256k1"
+name = "parity-secp256k1"
 version = "0.6.0"
 authors = [
   "Dawid Ciężarkiewicz <dpc@ucore.info>",


### PR DESCRIPTION
I've added dependency to this crate into parity-crypto crate https://github.com/paritytech/parity-common/pull/210/files 
So in order to publish new parity-crypto version, I need to publish this crate to crates.io as well. The name eth-secp256k1 is already taken, so I have to rename this to parity-secp256k1