### PR TITLE
Remove keyword for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/paritytech/rust-secp256k1/"
 repository = "https://github.com/paritytech/rust-secp256k1/"
 documentation = "https://www.wpsoftware.net/rustdoc/secp256k1/"
 description = "Fork of Rust bindings for Pieter Wuille's `libsecp256k1` library. Implements ECDSA for the SECG elliptic curve group secp256k1 and related utilities."
-keywords = [ "crypto", "ECDSA", "secp256k1", "libsecp256k1", "bitcoin", "ethereum" ]
+keywords = [ "ECDSA", "secp256k1", "libsecp256k1", "bitcoin", "ethereum" ]
 readme = "README.md"
 build = "build.rs"
 


### PR DESCRIPTION
Cargo publish doesn't like 6 keywords in crate description:
error: api errors (status 200 OK): invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 2298

I've removed "crypto" keyword (just the first one).