### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 [![Build Status](https://travis-ci.org/apoelstra/rust-secp256k1.png?branch=master)](https://travis-ci.org/apoelstra/rust-secp256k1)
 
-### rust-secp256k1
+### parity-secp256k1
 
-`rust-secp256k1` is a wrapper around [libsecp256k1](https://github.com/bitcoin/secp256k1),
+`parity-secp256k1` is a wrapper around [libsecp256k1](https://github.com/bitcoin/secp256k1),
 a C library by Peter Wuille for producing ECDSA signatures using the SECG curve
-`secp256k1`. This library
+`secp256k1`. It is a fork of [`rust-secp256k1`](https://github.com/rust-bitcoin/rust-secp256k1).
+ 
+This library
 * exposes type-safe Rust bindings for all `libsecp256k1` functions
 * implements key generation
 * implements deterministic nonce generation via RFC6979
@@ -12,4 +14,14 @@ a C library by Peter Wuille for producing ECDSA signatures using the SECG curve
 * makes no allocations (except in unit tests) for efficiency and use in freestanding implementations
 
 [Full documentation](https://www.wpsoftware.net/rustdoc/secp256k1/)
+
+#### Build
+
+Clone the repository. Run the following:
+
+```
+git submodule init
+git submodule update
+cargo check
+```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 [![Build Status](https://travis-ci.org/apoelstra/rust-secp256k1.png?branch=master)](https://travis-ci.org/apoelstra/rust-secp256k1)
+![crates.io](https://img.shields.io/crates/v/parity-secp256k1.svg)
+[![](https://tokei.rs/b1/github/paritytech/rust-secp256k1)](https://github.com/paritytech/rust-secp256k1)
+
 
 ### parity-secp256k1
 


### PR DESCRIPTION
Use the correct name: `parity-secp256k1`. Document that there's a submodule involved.