### PR TITLE
Remove all usage of `mem::uninitialized()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-secp256k1"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
   "Dawid Ciężarkiewicz <dpc@ucore.info>",
   "Andrew Poelstra <apoelstra@wpsoftware.net>",

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -32,7 +32,7 @@ impl SharedSecret {
     #[inline]
     pub fn new(secp: &Secp256k1, point: &PublicKey, scalar: &SecretKey) -> SharedSecret {
         unsafe {
-            let mut ss = ffi::SharedSecret::blank();
+            let mut ss = ffi::SharedSecret::new();
             let res = ffi::secp256k1_ecdh(secp.ctx,
                                           &mut ss,
                                           point.as_ptr(),
@@ -48,7 +48,7 @@ impl SharedSecret {
     #[inline]
     pub fn new_raw(secp: &Secp256k1, point: &PublicKey, scalar: &SecretKey) -> SharedSecret {
         unsafe {
-            let mut ss = ffi::SharedSecret::blank();
+            let mut ss = ffi::SharedSecret::new();
             let res = ffi::secp256k1_ecdh_raw(secp.ctx, &mut ss, point.as_ptr(), scalar.as_ptr());
             debug_assert_eq!(res, 1);
             SharedSecret(ss)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -77,9 +77,6 @@ impl_raw_debug!(PublicKey);
 impl PublicKey {
     /// Create a new (zeroed) public key usable for the FFI interface
     pub fn new() -> PublicKey { PublicKey([0; 64]) }
-    /// Create a new (uninitialized) public key usable for the FFI interface
-    #[deprecated(since = "0.7", note = "Please use the new function instead")]
-    pub unsafe fn blank() -> PublicKey { PublicKey::new() }
 }
 
 impl hash::Hash for PublicKey {
@@ -103,17 +100,11 @@ impl_raw_debug!(RecoverableSignature);
 impl Signature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> Signature { Signature([0; 64]) }
-    /// Create a new (uninitialized) signature usable for the FFI interface
-    #[deprecated(since = "0.7", note = "Please use the new function instead")]
-    pub unsafe fn blank() -> Signature { Signature::new() }
 }
 
 impl RecoverableSignature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> RecoverableSignature { RecoverableSignature([0; 65]) }
-    /// Create a new (uninitialized) signature usable for the FFI interface
-    #[deprecated(since = "0.7", note = "Please use the new function instead")]
-    pub unsafe fn blank() -> RecoverableSignature { RecoverableSignature::new() }
 }
 
 /// Library-internal representation of an ECDH shared secret
@@ -125,9 +116,6 @@ impl_raw_debug!(SharedSecret);
 impl SharedSecret {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> SharedSecret { SharedSecret([0; 32]) }
-    /// Create a new (uninitialized) signature usable for the FFI interface
-    #[deprecated(since = "0.7", note = "Please use the new function instead")]
-    pub unsafe fn blank() -> SharedSecret { SharedSecret::new() }
 }
 
 extern "C" {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -16,7 +16,6 @@
 //! # FFI bindings
 //! Direct bindings to the underlying C library functions. These should
 //! not be needed for most users.
-use std::mem;
 use std::hash;
 use std::os::raw::{c_int, c_uchar, c_uint, c_void};
 
@@ -79,7 +78,8 @@ impl PublicKey {
     /// Create a new (zeroed) public key usable for the FFI interface
     pub fn new() -> PublicKey { PublicKey([0; 64]) }
     /// Create a new (uninitialized) public key usable for the FFI interface
-    pub unsafe fn blank() -> PublicKey { mem::uninitialized() }
+    #[deprecated(since = "0.7", note = "Please use the new function instead")]
+    pub unsafe fn blank() -> PublicKey { PublicKey::new() }
 }
 
 impl hash::Hash for PublicKey {
@@ -104,14 +104,16 @@ impl Signature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> Signature { Signature([0; 64]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> Signature { mem::uninitialized() }
+    #[deprecated(since = "0.7", note = "Please use the new function instead")]
+    pub unsafe fn blank() -> Signature { Signature::new() }
 }
 
 impl RecoverableSignature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> RecoverableSignature { RecoverableSignature([0; 65]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> RecoverableSignature { mem::uninitialized() }
+    #[deprecated(since = "0.7", note = "Please use the new function instead")]
+    pub unsafe fn blank() -> RecoverableSignature { RecoverableSignature::new() }
 }
 
 /// Library-internal representation of an ECDH shared secret
@@ -124,7 +126,8 @@ impl SharedSecret {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> SharedSecret { SharedSecret([0; 32]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> SharedSecret { mem::uninitialized() }
+    #[deprecated(since = "0.7", note = "Please use the new function instead")]
+    pub unsafe fn blank() -> SharedSecret { SharedSecret::new() }
 }
 
 extern "C" {

--- a/src/key.rs
+++ b/src/key.rs
@@ -171,7 +171,7 @@ impl PublicKey {
         if secp.caps == ContextFlag::VerifyOnly || secp.caps == ContextFlag::None {
             return Err(IncapableContext);
         }
-        let mut pk = unsafe { ffi::PublicKey::blank() };
+        let mut pk = ffi::PublicKey::new();
         unsafe {
             // We can assume the return value because it's not possible to construct
             // an invalid `SecretKey` without transmute trickery or something
@@ -186,7 +186,7 @@ impl PublicKey {
     pub fn from_slice(secp: &Secp256k1, data: &[u8])
                       -> Result<PublicKey, Error> {
 
-        let mut pk = unsafe { ffi::PublicKey::blank() };
+        let mut pk = ffi::PublicKey::new();
         unsafe {
             if ffi::secp256k1_ec_pubkey_parse(secp.ctx, &mut pk, data.as_ptr(),
                                               data.len() as usize) == 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ impl Signature {
     #[inline]
     /// Converts a DER-encoded byte slice to a signature
     pub fn from_der(secp: &Secp256k1, data: &[u8]) -> Result<Signature, Error> {
-        let mut ret = unsafe { ffi::Signature::blank() };
+        let mut ret = ffi::Signature::new();
 
         unsafe {
             if ffi::secp256k1_ecdsa_signature_parse_der(secp.ctx, &mut ret,
@@ -109,7 +109,7 @@ impl Signature {
     /// support serializing to this "format"
     pub fn from_der_lax(secp: &Secp256k1, data: &[u8]) -> Result<Signature, Error> {
         unsafe {
-            let mut ret = ffi::Signature::blank();
+            let mut ret = ffi::Signature::new();
             if ffi::ecdsa_signature_parse_der_lax(secp.ctx, &mut ret,
                                                   data.as_ptr(), data.len() as usize) == 1 {
                 Ok(Signature(ret))
@@ -187,7 +187,7 @@ impl RecoverableSignature {
     /// representation is nonstandard and defined by the libsecp256k1
     /// library.
     pub fn from_compact(secp: &Secp256k1, data: &[u8], recid: RecoveryId) -> Result<RecoverableSignature, Error> {
-        let mut ret = unsafe { ffi::RecoverableSignature::blank() };
+        let mut ret = ffi::RecoverableSignature::new();
 
         unsafe {
             if data.len() != 64 {
@@ -224,7 +224,7 @@ impl RecoverableSignature {
     /// for verification
     #[inline]
     pub fn to_standard(&self, secp: &Secp256k1) -> Signature {
-        let mut ret = unsafe { ffi::Signature::blank() };
+        let mut ret = ffi::Signature::new();
         unsafe {
             let err = ffi::secp256k1_ecdsa_recoverable_signature_convert(secp.ctx, &mut ret, self.as_ptr());
             assert!(err == 1);
@@ -454,7 +454,7 @@ impl Secp256k1 {
     pub fn generate_keypair<R: Rng>(&self, rng: &mut R)
                                    -> Result<(key::SecretKey, key::PublicKey), Error> {
         let sk = key::SecretKey::new(self, rng);
-        let pk = try!(key::PublicKey::from_secret_key(self, &sk));
+        let pk = key::PublicKey::from_secret_key(self, &sk)?;
         Ok((sk, pk))
     }
 
@@ -466,7 +466,7 @@ impl Secp256k1 {
             return Err(Error::IncapableContext);
         }
 
-        let mut ret = unsafe { ffi::Signature::blank() };
+        let mut ret = ffi::Signature::new();
         unsafe {
             // We can assume the return value because it's not possible to construct
             // an invalid signature from a valid `Message` and `SecretKey`
@@ -485,7 +485,7 @@ impl Secp256k1 {
             return Err(Error::IncapableContext);
         }
 
-        let mut ret = unsafe { ffi::RecoverableSignature::blank() };
+        let mut ret = ffi::RecoverableSignature::new();
         unsafe {
             // We can assume the return value because it's not possible to construct
             // an invalid signature from a valid `Message` and `SecretKey`
@@ -504,7 +504,7 @@ impl Secp256k1 {
             return Err(Error::IncapableContext);
         }
 
-        let mut pk = unsafe { ffi::PublicKey::blank() };
+        let mut pk = ffi::PublicKey::new();
 
         unsafe {
             if ffi::secp256k1_ecdsa_recover(self.ctx, &mut pk,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,15 +54,8 @@ macro_rules! impl_array_newtype {
         impl Clone for $thing {
             #[inline]
             fn clone(&self) -> $thing {
-                unsafe {
-                    use std::intrinsics::copy_nonoverlapping;
-                    use std::mem;
-                    let mut ret: $thing = mem::uninitialized();
-                    copy_nonoverlapping(self.as_ptr(),
-                                        ret.as_mut_ptr(),
-                                        mem::size_of::<$thing>());
-                    ret
-                }
+                let &$thing(ref dat) = self;
+                $thing(dat.clone())
             }
         }
 
@@ -122,9 +115,9 @@ macro_rules! impl_pretty_debug {
     ($thing:ident) => {
         impl ::std::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                try!(write!(f, "{}(", stringify!($thing)));
+                write!(f, "{}(", stringify!($thing))?;
                 for i in self[..].iter().cloned() {
-                    try!(write!(f, "{:02x}", i));
+                    write!(f, "{:02x}", i)?;
                 }
                 write!(f, ")")
             }
@@ -137,7 +130,7 @@ macro_rules! impl_raw_debug {
         impl ::std::fmt::Debug for $thing {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 for i in self[..].iter().cloned() {
-                    try!(write!(f, "{:02x}", i));
+                    write!(f, "{:02x}", i)?;
                 }
                 Ok(())
             }


### PR DESCRIPTION
Backport from [upstream](https://github.com/rust-bitcoin/rust-secp256k1/pull/146).

Removes all calls to `mem::uninitialized` ~~and deprecates the methods that used it~~. Bumps version to `0.7`. 
~~I'd actually prefer to remove the various `::blank()` methods to avoid some version churn; thoughts on that?~~

Closes #23